### PR TITLE
Fix Python query runner print statment exception

### DIFF
--- a/redash/query_runner/python.py
+++ b/redash/query_runner/python.py
@@ -34,8 +34,11 @@ class CustomPrint(object):
     def disable(self):
         self.enabled = False
 
-    def __call__(self):
+    def __call__(self, *args):
         return self
+
+    def _call_print(self, *objects, **kwargs):
+        print(*objects, file=self)
 
 
 class Python(BaseQueryRunner):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description
The custom print function in Python query-runner for self-hosted Redash threw ```TypeError: __call__() takes 1 positional argument but 2 were given``` for print statements.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
